### PR TITLE
Setup static code analysis tools

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,30 @@
+# In all environments, the following files are loaded if they exist,
+# the latter taking precedence over the former:
+#
+#  * .env                contains default values for the environment variables needed by the app
+#  * .env.local          uncommitted file with local overrides
+#  * .env.$APP_ENV       committed environment-specific defaults
+#  * .env.$APP_ENV.local uncommitted environment-specific overrides
+#
+# Real environment variables win over .env files.
+#
+# DO NOT DEFINE PRODUCTION SECRETS IN THIS FILE NOR IN ANY OTHER COMMITTED FILES.
+# https://symfony.com/doc/current/configuration/secrets.html
+#
+# Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
+# https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
+
+###> symfony/framework-bundle ###
+APP_ENV=dev
+APP_SECRET=6e67395d20e55b45b65c2abc0749e0e6
+###< symfony/framework-bundle ###
+
+###> doctrine/doctrine-bundle ###
+# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
+# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
+#
+# DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
+# DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4"
+# DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
+DATABASE_URL="mysql://root:secret123@127.0.0.1:3306/product-api?serverVersion=8.0.32&charset=utf8mb4"
+###< doctrine/doctrine-bundle ###

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,11 @@
+# .env.test
+
+# Symfony Environment
+KERNEL_CLASS='App\Kernel'
+APP_SECRET='$ecretf0rt3st'
+SYMFONY_DEPRECATIONS_HELPER=999999
+PANTHER_APP_ENV=panther
+PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
+
+# Database Configuration
+DATABASE_URL="mysql://root:secret123@127.0.0.1:3306/product_api"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 /vendor/
 phpstan.neon
 
+
+###> squizlabs/php_codesniffer ###
+/.phpcs-cache
+/phpcs.xml
+###< squizlabs/php_codesniffer ###

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/.env.local
+/.env.local.php
+/.env.*.local
+/config/secrets/prod/prod.decrypt.private.php
+/public/bundles/
+/var/
+/vendor/
+phpstan.neon
+

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,1 +1,1 @@
-{"version":1,"defects":{"App\\Tests\\ProductTest::testItWorks":5,"App\\Tests\\ProductTest::testProducts":5},"times":{"App\\Tests\\ProductTest::testItWorks":0.353,"App\\Tests\\ProductTest::testProducts":0.003}}
+{"version":1,"defects":{"App\\Tests\\ProductTest::testItWorks":5,"App\\Tests\\ProductTest::testProducts":8},"times":{"App\\Tests\\ProductTest::testItWorks":0.353,"App\\Tests\\ProductTest::testProducts":0.003}}

--- a/.phpunit.result.cache
+++ b/.phpunit.result.cache
@@ -1,0 +1,1 @@
+{"version":1,"defects":{"App\\Tests\\ProductTest::testItWorks":5,"App\\Tests\\ProductTest::testProducts":5},"times":{"App\\Tests\\ProductTest::testItWorks":0.353,"App\\Tests\\ProductTest::testProducts":0.003}}

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     "scripts": {
         "test":"vendor/bin/phpunit",
         "phpstan": "php -d memory_limit=256M vendor/bin/phpstan analyse",
+        "phpcs": "vendor/bin/phpcs --standard=ruleset.xml src/",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
@@ -78,6 +79,7 @@
         "phpstan/phpstan": "^1.11",
         "phpstan/phpstan-doctrine": "^1.4",
         "phpunit/phpunit": "^11.2",
+        "squizlabs/php_codesniffer": "*",
         "symfony/browser-kit": "7.1.*",
         "symfony/css-selector": "7.1.*",
         "symfony/phpunit-bridge": "^7.1"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "allow-plugins": {
             "php-http/discovery": true,
             "symfony/flex": true,
-            "symfony/runtime": true
+            "symfony/runtime": true,
+            "phpstan/extension-installer": true
         },
         "sort-packages": true
     },
@@ -48,6 +49,8 @@
         "symfony/polyfill-php82": "*"
     },
     "scripts": {
+        "test":"vendor/bin/phpunit",
+        "phpstan": "php -d memory_limit=256M vendor/bin/phpstan analyse",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
@@ -71,6 +74,9 @@
     "require-dev": {
         "dama/doctrine-test-bundle": "^8.2",
         "doctrine/doctrine-fixtures-bundle": "^3.6",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-doctrine": "^1.4",
         "phpunit/phpunit": "^11.2",
         "symfony/browser-kit": "7.1.*",
         "symfony/css-selector": "7.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce7ac4cce964e2d763270cbe74e5ae5e",
+    "content-hash": "d5e5ffd16e52ff413d013527290c14bd",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -6183,6 +6183,86 @@
                 }
             ],
             "time": "2024-02-02T06:10:47+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/8f90f7a53ce271935282967f53d0894f8f1ff877",
+                "reference": "8f90f7a53ce271935282967f53d0894f8f1ff877",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-05-22T21:24:41+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "417138dcf2dbef3bd20d969907306bf2",
+    "content-hash": "ce7ac4cce964e2d763270cbe74e5ae5e",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -4663,6 +4663,180 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "f6b87faf9fc7978eab2f7919a8760bc9f58f9203"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/f6b87faf9fc7978eab2f7919a8760bc9f58f9203",
+                "reference": "f6b87faf9fc7978eab2f7919a8760bc9f58f9203",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.1"
+            },
+            "time": "2024-06-10T08:20:49+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.11.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "490f0ae1c92b082f154681d7849aee776a7c1443"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/490f0ae1c92b082f154681d7849aee776a7c1443",
+                "reference": "490f0ae1c92b082f154681d7849aee776a7c1443",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-06-17T15:10:54+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-doctrine",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-doctrine.git",
+                "reference": "dd27a3e83777ba0d9e9cedfaf4ebf95ff67b271f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/dd27a3e83777ba0d9e9cedfaf4ebf95ff67b271f",
+                "reference": "dd27a3e83777ba0d9e9cedfaf4ebf95ff67b271f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.11"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.0",
+                "doctrine/common": "<2.7",
+                "doctrine/mongodb-odm": "<1.2",
+                "doctrine/orm": "<2.5",
+                "doctrine/persistence": "<1.3"
+            },
+            "require-dev": {
+                "cache/array-adapter": "^1.1",
+                "composer/semver": "^3.3.2",
+                "cweagans/composer-patches": "^1.7.3",
+                "doctrine/annotations": "^1.11 || ^2.0",
+                "doctrine/collections": "^1.6 || ^2.1",
+                "doctrine/common": "^2.7 || ^3.0",
+                "doctrine/dbal": "^2.13.8 || ^3.3.3",
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "doctrine/mongodb-odm": "^1.3 || ^2.4.3",
+                "doctrine/orm": "^2.16.0",
+                "doctrine/persistence": "^2.2.1 || ^3.2",
+                "gedmo/doctrine-extensions": "^3.8",
+                "nesbot/carbon": "^2.49",
+                "nikic/php-parser": "^4.13.2",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.3.13",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^9.6.16",
+                "ramsey/uuid": "^4.2",
+                "symfony/cache": "^5.4"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Doctrine extensions for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.4.3"
+            },
+            "time": "2024-06-08T05:48:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,7 +10,7 @@ services:
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
-
+        public: false
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     App\:
@@ -19,6 +19,10 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
+            - '../src/Tests/*'
+            
+    App\Service\ProductService:
+        autowire: true
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+
+    <rule ref="PSR12"/>
+
+    <file>bin/</file>
+    <file>config/</file>
+    <file>public/</file>
+    <file>src/</file>
+    <file>tests/</file>
+
+</ruleset>

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,9 @@
+parameters:
+    level: 6
+    paths:
+        - src/
+        - tests/
+    
+
+    
+    

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -3,6 +3,17 @@ parameters:
     paths:
         - src/
         - tests/
+    bootstrapFiles:
+        - %rootDir%/../../autoload.php 
+    
+    checkUninitializedProperties: true
+    inferPrivatePropertyTypeFromConstructor: true
+    
+    ignoreErrors:
+        - '#Property .* has no type specified#'
+        - '#Property .* is never read, only written#'
+        - '#Method .* has no return type specified#'
+
     
 
     

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,348 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PSR12" xsi:noNamespaceSchemaLocation="../../../phpcs.xsd">
+    <description>The PSR-12 coding standard.</description>
+    <arg name="tab-width" value="4"/>
+
+    <!-- 2. General -->
+
+    <!-- 2.1 Basic Coding Standard -->
+
+    <!-- Code MUST follow all rules outlined in PSR-1. -->
+    <rule ref="PSR12"/>
+
+    <!-- The term 'StudlyCaps' in PSR-1 MUST be interpreted as PascalCase where the first letter of each word is capitalized including the very first letter. -->
+
+    <!-- 2.2 Files -->
+
+    <!-- All PHP files MUST use the Unix LF (linefeed) line ending only. -->
+    <rule ref="Generic.Files.LineEndings">
+        <properties>
+            <property name="eolChar" value="\n"/>
+        </properties>
+    </rule>
+
+    <!-- All PHP files MUST end with a non-blank line, terminated with a single LF. -->
+    <rule ref="PSR2.Files.EndFileNewline"/>
+
+    <!-- The closing ?> tag MUST be omitted from files containing only PHP. -->
+    <rule ref="PSR2.Files.ClosingTag"/>
+
+    <!-- 2.3 Lines -->
+
+    <!-- There MUST NOT be a hard limit on line length.
+    The soft limit on line length MUST be 120 characters.
+    Lines SHOULD NOT be longer than 80 characters; lines longer than that SHOULD be split into multiple subsequent lines of no more than 80 characters each. -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="0"/>
+        </properties>
+    </rule>
+
+    <!-- There MUST NOT be trailing whitespace at the end of lines.
+    Blank lines MAY be added to improve readability and to indicate related blocks of code except where explicitly forbidden. -->
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.StartFile">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EndFile">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines">
+        <severity>0</severity>
+    </rule>
+
+    <!-- There MUST NOT be more than one statement per line. -->
+    <rule ref="Generic.Formatting.DisallowMultipleStatements"/>
+
+    <!-- 2.4 Indenting -->
+
+    <!-- Code MUST use an indent of 4 spaces for each indent level, and MUST NOT use tabs for indenting. -->
+    <rule ref="Generic.WhiteSpace.ScopeIndent">
+        <properties>
+            <property name="ignoreIndentationTokens" type="array">
+                <element value="T_COMMENT"/>
+                <element value="T_DOC_COMMENT_OPEN_TAG"/>
+            </property>
+        </properties>
+    </rule>
+    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
+
+    <!-- 2.5 Keywords and Types -->
+
+    <!-- All PHP reserved keywords and types [1][2] MUST be in lower case.
+    Any new types and keywords added to future PHP versions MUST be in lower case. -->
+    <rule ref="Generic.PHP.LowerCaseKeyword"/>
+    <rule ref="Generic.PHP.LowerCaseConstant"/>
+    <rule ref="Generic.PHP.LowerCaseType"/>
+
+    <!-- Short form of type keywords MUST be used i.e. bool instead of boolean, int instead of integer etc. -->
+    <!-- checked by PSR12.Keywords.ShortFormTypeKeywords -->
+
+    <!-- 3. Declare Statements, Namespace, and Import Statements -->
+
+    <!-- The header of a PHP file may consist of a number of different blocks. If present, each of the blocks below MUST be separated by a single blank line, and MUST NOT contain a blank line. Each block MUST be in the order listed below, although blocks that are not relevant may be omitted.
+
+    Opening php tag.
+    File-level docblock.
+    One or more declare statements.
+    The namespace declaration of the file.
+    One or more class-based use import statements.
+    One or more function-based use import statements.
+    One or more constant-based use import statements.
+    The remainder of the code in the file. -->
+    <!-- checked by PSR12.Files.FileHeader -->
+
+    <!-- When a file contains a mix of HTML and PHP, any of the above sections may still be used. If so, they MUST be present at the top of the file, even if the remainder of the code consists of a closing PHP tag and then a mixture of HTML and PHP. -->
+
+    <!-- When the opening php tag is on the first line of the file, it MUST be on its own line with no other statements unless it is a file containing markup outside of PHP opening and closing tags. -->
+    <!-- checked by PSR12.Files.OpenTag -->
+
+    <!-- Import statements MUST never begin with a leading backslash as they must always be fully qualified. -->
+    <!-- checked by PSR12.Files.ImportStatement -->
+
+    <!-- Compound namespaces with a depth of more than two MUST NOT be used. -->
+    <!-- checked by PSR12.Namespaces.CompoundNamespaceDepth -->
+
+    <!-- When wishing to declare strict types in files containing markup outside PHP opening and closing tags, the declaration MUST be on the first line of the file and include an opening PHP tag, the strict types declaration and closing tag. -->
+    <!-- Declare statements MUST contain no spaces and MUST be exactly declare(strict_types=1) (with an optional semicolon terminator). -->
+    <!-- Block declare statements are allowed and MUST be formatted as below. -->
+    <!-- checked by PSR12.Files.DeclareStatement -->
+
+    <!-- 4. Classes, Properties, and Methods -->
+
+    <!-- Any closing brace MUST NOT be followed by any comment or statement on the same line. -->
+    <!-- checked by PSR12.Classes.ClosingBrace -->
+
+    <!-- When instantiating a new class, parentheses MUST always be present even when there are no arguments passed to the constructor. -->
+    <!-- checked by PSR12.Classes.ClassInstantiation -->
+
+    <!-- 4.1 Extends and Implements -->
+
+    <!-- The extends and implements keywords MUST be declared on the same line as the class name. -->
+    <!-- The opening brace for the class MUST go on its own line; the closing brace for the class MUST go on the next line after the body. -->
+    <!-- Opening braces MUST be on their own line and MUST NOT be preceded or followed by a blank line. -->
+    <!-- Closing braces MUST be on their own line and MUST NOT be preceded by a blank line. -->
+    <!-- Lists of implements and, in the case of interfaces, extends MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one interface per line. -->
+    <!-- checked by PSR12.Classes.OpeningBraceSpace -->
+    <rule ref="PSR2.Classes.ClassDeclaration"/>
+
+    <!-- 4.2 Using traits -->
+
+    <!-- The use keyword used inside the classes to implement traits MUST be declared on the next line after the opening brace. -->
+    <!-- Each individual trait that is imported into a class MUST be included one-per-line and each inclusion MUST have its own use import statement. -->
+    <!-- When the class has nothing after the use import statement, the class closing brace MUST be on the next line after the use import statement. Otherwise, it MUST have a blank line after the use import statement. -->
+    <!-- When using the insteadof and as operators they must be used as follows taking note of indentation, spacing, and new lines. -->
+    <!-- checked by PSR12.Traits.UseDeclaration -->
+
+    <!-- 4.3 Properties and Constants -->
+
+    <!-- Visibility MUST be declared on all properties. -->
+    <!-- The var keyword MUST NOT be used to declare a property. -->
+    <!-- There MUST NOT be more than one property declared per statement. -->
+    <!-- Property names MUST NOT be prefixed with a single underscore to indicate protected or private visibility.
+    That is, an underscore prefix explicitly has no meaning. -->
+    <!-- There MUST be a space between type declaration and property name. -->
+    <rule ref="PSR2.Classes.PropertyDeclaration"/>
+
+    <!-- Visibility MUST be declared on all constants if your project PHP minimum version supports constant visibilities (PHP 7.1 or later). -->
+    <!-- checked by PSR12.Properties.ConstantVisibility -->
+
+    <!-- 4.4 Methods and Functions -->
+
+    <!-- Visibility MUST be declared on all methods. -->
+    <rule ref="Squiz.Scope.MethodScope"/>
+    <rule ref="Squiz.WhiteSpace.ScopeKeywordSpacing"/>
+
+    <!-- Method names MUST NOT be prefixed with a single underscore to indicate protected or private visibility. That is, an underscore prefix explicitly has no meaning. -->
+    <rule ref="PSR2.Methods.MethodDeclaration"/>
+    <rule ref="PSR2.Methods.MethodDeclaration.Underscore">
+        <type>error</type>
+        <message>Method name "%s" must not be prefixed with an underscore to indicate visibility</message>
+    </rule>
+
+    <!-- Method and function names MUST NOT be declared with space after the method name. The opening brace MUST go on its own line, and the closing brace MUST go on the next line following the body. There MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. -->
+    <rule ref="PSR2.Methods.FunctionClosingBrace"/>
+    <rule ref="Squiz.Functions.FunctionDeclaration"/>
+    <rule ref="Squiz.Functions.LowercaseFunctionKeywords"/>
+
+    <!-- 4.5 Method and Function Arguments -->
+
+    <!-- In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma. -->
+    <!-- When using the reference operator & before an argument, there MUST NOT be a space after it. -->
+    <!-- There MUST NOT be a space between the variadic three dot operator and the argument name. -->
+    <!-- When combining both the reference operator and the variadic three dot operator, there MUST NOT be any space between the two of them. -->
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+        <properties>
+            <property name="equalsSpacing" value="1"/>
+        </properties>
+    </rule>
+
+    <!-- Method and function arguments with default values MUST go at the end of the argument list. -->
+    <rule ref="PEAR.Functions.ValidDefaultValue"/>
+
+    <!-- Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.
+    When the argument list is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
+    <rule ref="Squiz.Functions.MultiLineFunctionDeclaration"/>
+
+    <!-- When you have a return type declaration present, there MUST be one space after the colon followed by the type declaration. The colon and declaration MUST be on the same line as the argument list closing parenthesis with no spaces between the two characters. -->
+    <!-- checked by PSR12.Functions.ReturnTypeDeclaration -->
+
+    <!-- In nullable type declarations, there MUST NOT be a space between the question mark and the type. -->
+    <!-- checked by PSR12.Functions.NullableTypeDeclaration -->
+
+    <!-- 4.6 abstract, final, and static -->
+
+    <!-- When present, the abstract and final declarations MUST precede the visibility declaration. -->
+    <!-- When present, the static declaration MUST come after the visibility declaration. -->
+    <!-- checked by PSR2.Methods.MethodDeclaration included above -->
+
+    <!-- 4.7 Method and Function Calls -->
+
+    <!-- When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis, there MUST NOT be a space after the opening parenthesis, and there MUST NOT be a space before the closing parenthesis. In the argument list, there MUST NOT be a space before each comma, and there MUST be one space after each comma. -->
+    <!-- Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line. A single argument being split across multiple lines (as might be the case with an anonymous function or array) does not constitute splitting the argument list itself. -->
+    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+    <rule ref="PSR2.Methods.FunctionCallSignature"/>
+    <rule ref="PSR2.Methods.FunctionCallSignature.SpaceAfterCloseBracket">
+        <severity>0</severity>
+    </rule>
+    <rule ref="PSR2.Methods.FunctionCallSignature.OpeningIndent">
+        <severity>0</severity>
+    </rule>
+
+    <!-- 5. Control Structures -->
+
+    <!-- The general style rules for control structures are as follows:
+    There MUST be one space after the control structure keyword
+    There MUST NOT be a space after the opening parenthesis
+    There MUST NOT be a space before the closing parenthesis
+    There MUST be one space between the closing parenthesis and the opening brace
+    The structure body MUST be indented once
+    The body MUST be on the next line after the opening brace
+    The closing brace MUST be on the next line after the body
+    The body of each structure MUST be enclosed by braces. This standardizes how the structures look and reduces the likelihood of introducing errors as new lines get added to the body. -->
+    <rule ref="Squiz.ControlStructures.ControlSignature"/>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
+    <rule ref="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
+    <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingAfterOpen">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.ControlStructures.ForLoopDeclaration.SpacingBeforeClose">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.ControlStructures.LowercaseDeclaration"/>
+    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
+
+    <!-- exclude this message as it is already checked in Generic.PHP.LowerCaseKeyword -->
+    <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.AsNotLower">
+        <severity>0</severity>
+    </rule>
+
+    <!-- 5.1 if, elseif, else -->
+
+    <!-- else and elseif are on the same line as the closing brace from the earlier body. -->
+    <!-- checked by Squiz.ControlStructures.ControlSignature included above -->
+
+    <!-- The keyword elseif SHOULD be used instead of else if so that all control keywords look like single words. -->
+    <rule ref="PSR2.ControlStructures.ElseIfDeclaration"/>
+
+    <!-- Expressions in parentheses MAY be split across multiple lines, where each subsequent line is indented at least once. When doing so, the first condition MUST be on the next line. The closing parenthesis and opening brace MUST be placed together on their own line with one space between them. Boolean operators between conditions MUST always be at the beginning or at the end of the line, not a mix of both. -->
+    <!-- checked by PSR12.ControlStructures.ControlStructureSpacing -->
+    <!-- checked by PSR12.ControlStructures.BooleanOperatorPlacement -->
+    <!-- checked by Squiz.ControlStructures.ControlSignature -->
+
+    <!-- 5.2 switch, case -->
+
+    <!-- The case statement MUST be indented once from switch, and the break keyword (or other terminating keywords) MUST be indented at the same level as the case body. There MUST be a comment such as // no break when fall-through is intentional in a non-empty case body. -->
+    <rule ref="PSR2.ControlStructures.SwitchDeclaration"/>
+
+    <!-- Expressions in parentheses MAY be split across multiple lines, where each subsequent line is indented at least once. When doing so, the first condition MUST be on the next line. The closing parenthesis and opening brace MUST be placed together on their own line with one space between them. Boolean operators between conditions MUST always be at the beginning or at the end of the line, not a mix of both. -->
+    <!-- checked by PSR12.ControlStructures.ControlStructureSpacing -->
+    <!-- checked by PSR12.ControlStructures.BooleanOperatorPlacement -->
+    <!-- checked by Squiz.ControlStructures.ControlSignature -->
+
+    <!-- 5.3.1 while -->
+
+    <!-- Expressions in parentheses MAY be split across multiple lines, where each subsequent line is indented at least once. When doing so, the first condition MUST be on the next line. The closing parenthesis and opening brace MUST be placed together on their own line with one space between them. Boolean operators between conditions MUST always be at the beginning or at the end of the line, not a mix of both. -->
+    <!-- checked by PSR12.ControlStructures.ControlStructureSpacing -->
+    <!-- checked by PSR12.ControlStructures.BooleanOperatorPlacement -->
+    <!-- checked by Squiz.ControlStructures.ControlSignature -->
+
+    <!-- 5.3.2 do while -->
+
+    <!-- Expressions in parentheses MAY be split across multiple lines, where each subsequent line is indented at least once. When doing so, the first condition MUST be on the next line. Boolean operators between conditions MUST always be at the beginning or at the end of the line, not a mix of both. -->
+    <!-- checked by PSR12.ControlStructures.ControlStructureSpacing -->
+    <!-- checked by PSR12.ControlStructures.BooleanOperatorPlacement -->
+    <!-- checked by Squiz.ControlStructures.ControlSignature -->
+
+    <!-- 5.4 for -->
+
+    <!-- Expressions in parentheses MAY be split across multiple lines, where each subsequent line is indented at least once. When doing so, the first expression MUST be on the next line. The closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
+    <!-- checked by PSR12.ControlStructures.ControlStructureSpacing -->
+    <!-- checked by PSR12.ControlStructures.BooleanOperatorPlacement -->
+    <!-- checked by Squiz.ControlStructures.ControlSignature -->
+
+    <!-- 5.5 foreach -->
+
+    <!-- exclude these messages as they are already checked by PSR2.ControlStructures.ControlStructureSpacing -->
+    <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceAfterOpen">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration.SpaceBeforeClose">
+        <severity>0</severity>
+    </rule>
+
+    <!-- 5.6 try, catch, finally -->
+
+    <!-- 6. Operators -->
+
+    <!-- When space is permitted around an operator, multiple spaces MAY be used for readability purposes. -->
+    <!-- All operators not described here are left undefined. -->
+
+    <!-- 6.1. Unary operators -->
+
+    <!-- The increment/decrement operators MUST NOT have any space between the operator and operand. -->
+    <rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
+
+    <!-- Type casting operators MUST NOT have any space within the parentheses. -->
+    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
+
+    <!-- 6.2. Binary operators -->
+
+    <!-- All binary arithmetic, comparison, assignment, bitwise, logical, string, and type operators MUST be preceded and followed by at least one space. -->
+    <!-- checked by PSR12.Operators.OperatorSpacing -->
+
+    <!-- 6.3. Ternary operators -->
+
+    <!-- The conditional operator, also known simply as the ternary operator, MUST be preceded and followed by at least one space around both the ? and : characters. -->
+    <!-- When the middle operand of the conditional operator is omitted, the operator MUST follow the same style rules as other binary comparison operators. -->
+    <!-- checked by PSR12.Operators.OperatorSpacing -->
+
+    <!-- 7. Closures -->
+
+    <!-- Closures MUST be declared with a space after the function keyword, and a space before and after the use keyword. -->
+    <!-- The opening brace MUST go on the same line, and the closing brace MUST go on the next line following the body. -->
+    <!-- There MUST NOT be a space after the opening parenthesis of the argument list or variable list, and there MUST NOT be a space before the closing parenthesis of the argument list or variable list. -->
+    <!-- In the argument list and variable list, there MUST NOT be a space before each comma, and there MUST be one space after each comma. -->
+    <!-- Closure arguments with default values MUST go at the end of the argument list. -->
+    <!-- Argument lists and variable lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument or variable per line. -->
+    <!-- When the ending list (whether of arguments or variables) is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them. -->
+    <!-- checked by Squiz.Functions.MultiLineFunctionDeclaration -->
+
+    <!-- If a return type is present, it MUST follow the same rules as with normal functions and methods; if the use keyword is present, the colon MUST follow the use list closing parentheses with no spaces between the two characters. -->
+    <!-- checked by PSR12.Functions.ReturnTypeDeclaration -->
+
+    <!-- 8. Anonymous Classes -->
+
+    <!-- Anonymous Classes MUST follow the same guidelines and principles as closures in the above section. -->
+    <!-- The opening brace MAY be on the same line as the class keyword so long as the list of implements interfaces does not wrap. If the list of interfaces wraps, the brace MUST be placed on the line immediately following the last interface. -->
+    <!-- checked by PSR12.Classes.AnonClassDeclaration -->
+
+</ruleset>

--- a/src/Controller/ProductsController.php
+++ b/src/Controller/ProductsController.php
@@ -2,23 +2,24 @@
 
 namespace App\Controller;
 
-use App\Repository\ProductRepository;
+use App\Service\ProductService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 class ProductsController extends AbstractController
 {
-    private $productRepository;
+    private $productService;
 
-    public function __construct(ProductRepository $productRepository)
+    public function __construct(ProductService $productService)
     {
-        $this->productRepository = $productRepository;
+        $this->productService = $productService;
     }
+
     #[Route('/products', name: 'products')]
-    public function all(): JsonResponse
+    public function index(): JsonResponse
     {
-        $products = $this->productRepository->findAll();
+        $products = $this->productService->getAllProducts();
         return $this->json($products);
     }
 }

--- a/src/Repository/ProductRepository.php
+++ b/src/Repository/ProductRepository.php
@@ -16,6 +16,13 @@ class ProductRepository extends ServiceEntityRepository
         parent::__construct($registry, Product::class);
     }
 
+    public function findAllProducts(): array
+    {
+        return $this->createQueryBuilder('p')
+            ->getQuery()
+            ->getResult();
+    }
+
 //    /**
 //     * @return Product[] Returns an array of Product objects
 //     */

--- a/src/Services/ProductService.php
+++ b/src/Services/ProductService.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Service;
+ 
+use App\Repository\ProductRepository;
+
+class ProductService
+{
+    private $productRepository;
+
+    public function __construct(ProductRepository $productRepository)
+    {
+        $this->productRepository = $productRepository;
+    }
+
+    public function getAllProducts(): array
+    {
+        return $this->productRepository->findAllProducts();
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -76,6 +76,18 @@
             "tests/bootstrap.php"
         ]
     },
+    "squizlabs/php_codesniffer": {
+        "version": "3.10",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "3.6",
+            "ref": "1019e5c08d4821cb9b77f4891f8e9c31ff20ac6f"
+        },
+        "files": [
+            "phpcs.xml.dist"
+        ]
+    },
     "symfony/console": {
         "version": "7.1",
         "recipe": {

--- a/symfony.lock
+++ b/symfony.lock
@@ -50,6 +50,18 @@
             "migrations/.gitignore"
         ]
     },
+    "phpstan/phpstan": {
+        "version": "1.11",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "5e490cc197fb6bb1ae22e5abbc531ddc633b6767"
+        },
+        "files": [
+            "phpstan.dist.neon"
+        ]
+    },
     "phpunit/phpunit": {
         "version": "11.2",
         "recipe": {


### PR DESCRIPTION

Configure PHPStan, PHP CodeSniffer and refactor controllers/repositories to use services

- Configure PHPStan and PHPCodeSniffer for static analysis and dependency checking 
- Updated controllers and repositories to utilize services for cleaner, reusable code 

